### PR TITLE
fix(interpreter): prevent indefinite hang when subprocess dies before EOF

### DIFF
--- a/treesearch/interpreter.py
+++ b/treesearch/interpreter.py
@@ -299,8 +299,15 @@ class Interpreter:
         # read all stdout/stderr from child up to the EOF marker
         # waiting until the queue is empty is not enough since
         # the feeder thread in child might still be adding to the queue
+        # After a timeout+cleanup the subprocess is dead and will never send
+        # <|EOF|>, so we use a short get() timeout to break out instead of
+        # blocking forever.
         while not self.result_outq.empty() or not output or output[-1] != "<|EOF|>":
-            output.append(self.result_outq.get())
+            try:
+                output.append(self.result_outq.get(timeout=2))
+            except queue.Empty:
+                output.append("<|EOF|>")
+                break
         output.pop()  # remove the EOF marker
 
         e_cls_name, exc_info, exc_stack = state[1:]


### PR DESCRIPTION
## Summary

Fixes an indefinite hang in `Interpreter.run()` that occurs when the child subprocess terminates before emitting the `<|EOF|>` marker (e.g. after a timeout-triggered `cleanup_session()`, OOM-kill, or external kill).

## Problem

After `cleanup_session()` drains the queue and kills the subprocess, control returns to the output-read loop in `treesearch/interpreter.py`:

```python
while not self.result_outq.empty() or not output or output[-1] != "<|EOF|>":
    output.append(self.result_outq.get())
```

Since the queue is empty *and* the producer is dead, `result_outq.get()` blocks forever — there is no longer any process that could put `<|EOF|>` into the queue, and `multiprocessing.Queue` does not detect a dead producer. The whole AutoRecLab run hangs and must be killed manually.

## Reproduction

1. Set a short `timeout` in `config.toml` (e.g. `timeout = 60`)
2. Submit a prompt that produces code requiring more than 60 s
3. After the timeout fires and cleanup completes, the run hangs in the output-read loop instead of advancing to the next tree-search iteration.

Reproduced reliably on Windows 11 + Python 3.11 in a 10-iteration tree search: one iteration timed out → the run never recovered and had to be killed manually.

## Fix

Wrap `result_outq.get()` with `timeout=2` and a `queue.Empty` handler. On timeout we synthesize the `<|EOF|>` marker ourselves to break out of the loop. The happy path (child sends EOF normally) is unchanged because `get(timeout=2)` returns immediately when data is available.

## Risk

Minimal. The change only alters behaviour in the failure path that previously hung indefinitely. In the success path, behaviour is identical. `import queue` already exists at the top of the file, no new imports needed.

## Test plan

- [x] Manual: previously hung iteration → with this fix, the next iteration starts within 2 seconds of the timeout.
- [x] Existing happy-path runs continue to terminate normally and produce identical output.
