### PR TITLE
feat: add /model command

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from argparse import ArgumentParser
 
@@ -33,12 +34,31 @@ async def main():
     
     require_executable("dot")
 
+    with open("pricing.json") as f:
+        pricing = {m["model"]: m for m in json.load(f)["models"]}
+
     user_req_lines: list[str] = []
-    print('Enter you request, write "!start" to start:')
+    print('Enter your request, write "!start" to start (use /model to change model):')
     while True:
         line = input("> ")
         if line.lower().strip().startswith("!start"):
             break
+
+        if line.lower().strip().startswith("/model"):
+            parts = line.split()
+            if len(parts) == 1 or parts[1] == "list":
+                print()
+                for name, info in pricing.items():
+                    cur = "  <- current" if name == config.agent.code.model else ""
+                    print(f"  {name}  | ${info['input']}/{info['output']} per 1M{cur}")
+                print()
+            elif len(parts) == 2 and parts[1] in pricing:
+                config.agent.code.model = parts[1]
+                print(f"Switched to {parts[1]}.")
+            else:
+                print(f"Unknown model '{parts[1]}'. Try /model")
+            continue
+
         user_req_lines.append(line)
 
     user_request = "\n".join(user_req_lines)

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ async def main():
     
     require_executable("dot")
 
-    with open("pricing.json") as f:
+    with open("pricing.json", "r") as f:
         pricing = {m["model"]: m for m in json.load(f)["models"]}
 
     user_req_lines: list[str] = []


### PR DESCRIPTION
## Description

Adds a /model command to the interactive prompt for switching the LLM at runtime before starting the tree search.

## Key Changes
- /model or /model list — lists available models with pricing, highlighting the current one
- /model <name> — switches to that model
- Prompts loaded from pricing.json, updated input prompt text to mention the command