### PR TITLE
Feat/Fix: Save final search report and improve console output formatting 

### DIFF
--- a/treesearch/minimal_agent.py
+++ b/treesearch/minimal_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import humanize
+from rich.console import Console
 
 from config import Config
 from treesearch.function_specs import (
@@ -22,6 +23,7 @@ from treesearch.utils.response import strip_markdown_fences
 from utils.log import _ROOT_LOGGER
 from utils.path import mkdir
 
+console = Console()
 logger = _ROOT_LOGGER.getChild("nodeAgent")
 
 
@@ -139,10 +141,10 @@ class MinimalAgent:
         prompt["Instructions"] |= self._prompt_impl_guideline
         prompt["Instructions"] |= self._prompt_environment
 
-        print("[cyan]--------------------------------[/cyan]")
-        print("[cyan]self.task_desc[/cyan]")
-        print("[cyan]" + self.task_desc + "[/cyan]")
-        print("[cyan]--------------------------------[/cyan]")
+        console.print("--------------------------------", style="cyan")
+        console.print("self.task_desc", style="cyan")
+        console.print(self.task_desc, style="cyan")
+        console.print("--------------------------------", style="cyan")
 
         print("MinimalAgent: Getting plan and code")
         plan, code = await self.plan_and_code_query(prompt)

--- a/treesearch/search.py
+++ b/treesearch/search.py
@@ -214,8 +214,25 @@ class TreeSearch:
     async def finalize_search(self, result_node: Node):
         self._interpreter.cleanup_session()
         logger.info(f"Finalizing search with node: {result_node.id}")
+        final_report = await self._minimal_agent._summarize(self._user_request, result_node)
+        report_path = self._out_dir / "final_report.txt"
+        self._write_text_report(report_path, final_report, result_node)
+        logger.info(f"Final report written to {report_path}")
         logger.info("Final response:")
-        print(await self._minimal_agent._summarize(self._user_request, result_node))
+        print(final_report)
+
+    def _write_text_report(self, report_path: Path, final_report: str, result_node: Node) -> None:
+        report_text = "\n".join(
+            [
+                "AutoRecLab Final Report",
+                f"Selected node: {result_node.id}",
+                f"Score: {result_node.score.score:.4f}",
+                "",
+                final_report,
+                "",
+            ]
+        )
+        report_path.write_text(report_text, encoding="utf-8")
 
     @property
     def _task_desc(self) -> str:


### PR DESCRIPTION
This PR adds writing the final AutoRecLab search summary to final_report.txt, including the selected node ID and score, while still printing the report to the console.

It also replaces styled print calls in minimal_agent.py with Rich Console.print() for cleaner formatted terminal output.