### PR TITLE
fix(treesearch): prevent search.py from moving static datasets

### DIFF
--- a/treesearch/search.py
+++ b/treesearch/search.py
@@ -193,16 +193,34 @@ class TreeSearch:
         # Move all generated files from the workspace to checkpoint for this node
         workspace_dir = Path(self._workspace)
         working_dir = workspace_dir / "working"
-        
+        """ 
+        Old: Leads to issues where agent generates files, then in next iteration tries to read from workspace 
+        but files are gone since we moved them to checkpoint. We want to keep files in workspace until the end of the iteration, 
+        then move them all at once at the end of exec_node.
+
         # Collect files from workspace (excluding runfile.py and working dir)
-        generated_files = [
+        /*generated_files = [
             item for item in workspace_dir.iterdir()
             if item.name not in ("runfile.py", "working") and not item.name.startswith(".")
         ]
+        """
+        # PR Group 01: Definierte Dateiformate, die nicht gemoved werden sollen.
+        ignored_extensions = (".csv", ".data", ".tsv", ".zip", ".gz")
+
+        # 1. Dateien aus dem Haupt-Workspace sammeln (gefiltert)
+        generated_files = [
+            item for item in workspace_dir.iterdir()
+            if item.name not in ("runfile.py", "working") 
+            and not item.name.startswith(".")
+            and item.suffix.lower() not in ignored_extensions
+        ]
         
-        # Also collect files from working subdirectory if it exists
+        # 2. Dateien aus dem working-Unterordner sammeln 
         if working_dir.exists():
-            generated_files.extend(list(working_dir.iterdir()))
+            generated_files.extend([
+                item for item in working_dir.iterdir()
+                if item.suffix.lower() not in ignored_extensions
+            ])
 
         # Keep only relevant files via whitelist
         if self._config.exec.keep_only_relevant_files:
@@ -220,11 +238,10 @@ class TreeSearch:
                         os.remove(str(item))
 
             generated_files = keep
-
         else:
             logger.info("Keeping all files.")
         
-        
+        # Das eigentliche Verschieben in den Checkpoint
         if generated_files:
             generated_dir = mkdir(node_dir / "generated")
             for item in generated_files:


### PR DESCRIPTION
# **Summary**
Introduces an extension-based blacklist filter in search.py to prevent static datasets from being destructively moved to node checkpoints during tree-search iterations, significantly reducing disk-space overhead and pipeline crashes.
# **Problem**
In the current state of AutoRecLab, the exec_node method indiscriminately collects all files within the workspace and uses shutil.move() to transfer them into the current node's checkpoint directory. This catches agent-generated artifacts (like plots or results), but datasets (e.g., u.data, .csv, .zip files) as well.

This automated moving behavior causes severe architectural issues:

Pipeline Disruption (FileNotFoundError): Once a dataset is moved to a checkpoint during the first iteration, it is missing from the workspace root in subsequent iterations, causing follow-up runs to crash.

Massive Memory Overhead: If users rely on automated loaders to bypass the missing files, the framework forces redownloads and recanonicalizations for every single node, duplicating gigabytes of data across countless hash-named checkpoint folders and triggering No space left on device errors eventually.

Dirty Git Tree: Moving local files constantly flags the datasets as "deleted" or "untracked" in the user's repository state.

# **Solution**
We modified the file aggregation phase in search.py by introducing a robust extension-based filter (ignored_extensions).

Input vs. Output Separation: The framework now explicitly ignores typical dataset formats (.csv, .data, .tsv, .zip, .gz) when collecting files from both the workspace root and the working/ subdirectory.

Non-Destructive Execution: Static inputs safely persist in the workspace across all iterations, allowing the user to copy datasets once into the directory without them being wiped out.

Storage Optimization: Only true agent-generated artifacts (such as evaluation summaries or logs) are moved to the checkpoint folder, keeping the disk usage minimal and the Git tree clean.