### PR TITLE
fix: add request timeout to prevent infinite hangs during scoring loop

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,6 +23,8 @@ class ExecConfig(BaseSettings):
 class CodeConfig(BaseSettings):
     model: str = "gpt-5-mini"
     model_temp: float = 1.0
+    request_timeout: int = 120
+    max_retries: int = 3
 
 
 class AgentConfig(BaseSettings):

--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,5 @@ k_fold_validation = 1
 [agent.code]
 model = "gpt-5.4-mini"
 model_temp = 1.0
+request_timeout = 120
+max_retries = 3

--- a/treesearch/llm/query.py
+++ b/treesearch/llm/query.py
@@ -93,8 +93,14 @@ class Query:
         input = prompt_to_md(input)
         tools = await self._get_all_tools()
 
+        from config import get_config
+        _cfg = get_config()
         model = ChatOpenAI(
-            model=self._model, temperature=self._temperature, use_responses_api=True
+            model=self._model,
+            temperature=self._temperature,
+            use_responses_api=True,
+            timeout=_cfg.agent.code.request_timeout,
+            max_retries=_cfg.agent.code.max_retries,
         )
 
         agent = Agent(


### PR DESCRIPTION
## Add request timeout to prevent infinite hangs during scoring loop

Midway through the pipeline, I noticed that it got stuck indefinitely because the API stopped responding. :(

### Problem
The pipeline can hang indefinitely when the OpenAI API server stops responding midrequest.

### Error flow
During the detailed requirement scoring loop in `minimal_agent.py`, every requirement triggers a separate API call. Earlier logs show a `503 Service Unavailable` that eventually succeeded after retry. At some point the API connection stalled silently ? the traceback shows `httpcore` blocked on `self._protocol.read_event.wait()` with **no timeout** configured on `ChatOpenAI`. The `asyncio.exceptions.CancelledError` only appeared after a manual `KeyboardInterrupt`; without that the process hangs forever.

### Fix
Added `timeout` and `max_retries` to the `ChatOpenAI` constructor in `treesearch/llm/query.py`:

```python
_cfg = get_config()
model = ChatOpenAI(
    model=self._model,
    temperature=self._temperature,
    use_responses_api=True,
    timeout=_cfg.agent.code.request_timeout,   # 120 seconds
    max_retries=_cfg.agent.code.max_retries,    # 3 retries
)
```

Parameters are reused from config.toml

| Parameter         | Value | Description                |
|-------------------|-------|----------------------------|
| `request_timeout` | 120s  | Timeout per API call       |
| `max_retries`     | 3     | Automatic retry attempts   |

Why it works.. 

A x-second timeout ensures unresponsive calls raise a httpx.TimeoutException instead of hanging forever.
The exception is caught by the existing try/except blocks in minimal_agent.py, which mark the requirement as is_fulfilled=False and continue the pipeline gracefully.
3 automatic retries handle transient failures (like the observed 503) without manual intervention.