### PR TITLE
fix: isolate each run's outputs in a timestamped subdirectory

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
 from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
 from config import get_config
 from treesearch.search import TreeSearch
 from utils.log import _ROOT_LOGGER, attach_file_handler, set_log_level
@@ -44,6 +46,13 @@ async def main():
     # Set model in config if provided as argument
     if args.model is not None:
         config.agent.code = config.agent.code.model_copy(update={"model": args.model})
+
+
+    # Isolate this run's outputs in a timestamped subdirectory so artifacts from
+    # different runs are not mixed in the same out/ directory.
+    run_id = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    config = config.model_copy(update={"out_dir": str(Path(config.out_dir) / f"run_{run_id}")})
+    out_dir = mkdir(config.out_dir)
 
 
     # Prepare to run AutoRecLab


### PR DESCRIPTION
## Problem
All runs write into the same `out/` directory. A second run piles its
artifacts on top of the previous one — e.g. `out/statistics/` and
`out/checkpoint/` end up with mixed files from different runs, which makes
per-run analysis unreliable.

## Fix
Each run now writes into a timestamped subdirectory, e.g.
`out/run_2026-06-22_10-21-05/`. Runs are fully isolated and nothing is
overwritten or deleted.

The change is small because the output path is centralized: once
`config.out_dir` is updated, every writer inherits it (file logger, cost
tracker, statistics tracker, `save.pkl`, `checkpoint/`, `tree_render/`).
`TreeSearch` reads `config.out_dir` directly, so the config value is updated
(not just a local variable). Timestamping happens after the
`--init` / `--list-*` early returns, so those still use `./out`.

## Testing
Two consecutive minimal runs each produced their own `run_<timestamp>/`
folder; the top-level `out/` contained no loose artifacts and nothing was
overwritten.
