### PR TITLE
perf(scoring): parallelize per-requirement evaluation with asyncio.gather

### DIFF
--- a/treesearch/minimal_agent.py
+++ b/treesearch/minimal_agent.py
@@ -2,6 +2,7 @@ import json
 import random
 from pathlib import Path
 from typing import Any, Optional
+import asyncio
 
 import humanize
 
@@ -513,8 +514,10 @@ class MinimalAgent:
         # Proceed with detailed scoring regardless of bug status
         logger.info("Proceeding with detailed scoring")
 
-        # Use the scoring system
-        for req in node.requirements:
+        # Score each requirement with an independent LLM call.
+        # Requirements are independent of each other, so we evaluate them
+        # concurrently with asyncio.gather to reduce wall-clock time.
+        async def _score_requirement(req: Requirement) -> None:
             logger.debug("Scoring requirement: %s", req.description)
             scoring_prompt: Prompt = {
                 "Instructions": (
@@ -554,6 +557,8 @@ class MinimalAgent:
                 # Fallback requirement feedback
                 req.is_fulfilled = False
                 req.feedback = "No specific feedback provided."
+
+        await asyncio.gather(*(_score_requirement(req) for req in node.requirements))
 
         all_fulfilled = all(r.is_fulfilled for r in node.requirements)
         logger.debug("All requirements fulfilled=%s", all_fulfilled)


### PR DESCRIPTION
## Summary

Refactors `MinimalAgent.score_code` so that per-requirement evaluations run concurrently via `asyncio.gather` instead of a sequential `for` loop. Each requirement is evaluated by an independent LLM call, so parallelizing them is safe and substantially reduces wall-clock time.

## Motivation

Currently, `score_code` iterates over `node.requirements` and awaits one LLM call per requirement before moving to the next:

```python
for req in node.requirements:
    scoring_result = await Query(...).run(scoring_prompt, ScoreCode)
```

This loop runs for every executed node — both drafts and tree-search iterations. With the default configuration (`num_draft_nodes=3`, `max_iterations=10`) and N requirements per node, scoring contributes roughly `13 * N` strictly sequential LLM calls in the critical path of a single run.

## Change

- Wraps the per-requirement scoring logic into an inner `async def _score_requirement(req)`.
- Dispatches all requirements concurrently with `await asyncio.gather(...)`.
- Existing per-requirement exception handling (mark unfulfilled, leave fallback feedback) is preserved verbatim.
- Adds `import asyncio` at the top of the module.

No public API changes. No behavioral differences expected for individual requirements; only the order in which results return is non-deterministic, which the surrounding code does not rely on (`all_fulfilled`, the feedback assembly loop, and the coverage confirmation step are all order-independent).

## Impact

Wall-clock time of the scoring phase scales with the slowest individual call instead of the sum of all calls. For a node with N requirements, this is up to an Nx speedup for that phase. Total API cost is unchanged (same number of calls).

## Notes for reviewers

- The inner async function captures `node`, `self.task_desc`, and `self._mcp_docs` from the enclosing scope — the same references the original loop used.
- The bug-review LLM call earlier in `score_code` (the `ReviewFunction` call) already runs before this block, so the shared `_MCP_CACHE` in `query.py` is guaranteed to be warm before the parallel section. No cache-race window is introduced.

### Optional follow-up: bounded concurrency

The cached `MultiServerMCPClient` is shared across all concurrent `Query.run()` calls via a single stdio transport to `docs_search_server`. If `langchain_mcp_adapters` does not safely multiplex concurrent tool calls over one stdio MCP client, or if a user's OpenAI tier has tight RPM limits, the unbounded `gather` could become a problem.

In that case, the fix is to bound the concurrency with a small semaphore:

```python
_scoring_sem = asyncio.Semaphore(3)
async def _bounded_score(req):
    async with _scoring_sem:
        await _score_requirement(req)
await asyncio.gather(*(_bounded_score(req) for req in node.requirements))
```

This caps in-flight scoring calls at 3, which preserves most of the wall-clock benefit (~3x speedup) while removing any risk of overloading the shared MCP stdio channel. Happy to incorporate this into the PR directly if preferred.