### PR TITLE
feat(interpreter): clean up leftover agent file in cleanup_session

### DIFF
--- a/treesearch/interpreter.py
+++ b/treesearch/interpreter.py
@@ -69,8 +69,12 @@ class Interpreter:
         self.agent_file_path = self.working_dir / agent_file_name
 
     def cleanup_session(self):
-        # TODO: Do some cleanup here if necessary
-        pass
+        try:
+            if self.agent_file_path.exists():
+                self.agent_file_path.unlink()
+                logger.debug(f"Removed leftover agent file: {self.agent_file_path}")
+        except OSError as e:
+            logger.warning(f"Failed to remove agent file {self.agent_file_path}: {e}")
 
     def run(
         self,


### PR DESCRIPTION
## Summary

Implements `Interpreter.cleanup_session` so the interpreter removes the leftover agent file after a run.

## Motivation

The interpreter writes generated code to `workspace/runfile.py` during execution, but the file was not removed after the run finished. This left the workspace with a stale file from the last executed node.

## Change

`cleanup_session` now deletes `self.agent_file_path` if it exists. Cleanup failures are logged as warnings and do not interrupt the run.

## Impact

- Removes stale `runfile.py` files after completed runs
- Keeps the workspace cleaner
- Does not change execution behavior