### PR TITLE
fix: CLI startup logic architecture more robustly and clearly

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
 import asyncio
 import os
 from argparse import ArgumentParser
+
 from config import get_config
 from treesearch.search import TreeSearch
+from utils.checks import require_executable
+from treesearch.utils.available_datasets import get_datasets_table
+from treesearch.utils.costs_tracker import get_cost_tracker, get_model_table
 from utils.log import _ROOT_LOGGER, attach_file_handler, set_log_level
 from utils.path import mkdir
-from utils.checks import require_executable
-from treesearch.utils.costs_tracker import get_cost_tracker, get_model_table
 from utils.statistics_tracker import get_statistics_tracker
-from treesearch.utils.available_datasets import get_datasets_table
 
 logger = _ROOT_LOGGER.getChild("main")
 cost_tracker = get_cost_tracker()
@@ -22,79 +23,81 @@ async def main():
     out_dir = mkdir(config.out_dir)
     args = get_args()
 
-    #Init workspace
-    if args.init:
-        mkdir(out_dir / "workspace")
+    if handle_management_command(args, out_dir):
         return
 
-
-    # List available datasets
-    if args.list_datasets:
-        datasets_table = get_datasets_table()
-        print(datasets_table)
-        return
-
-
-    # List available models
-    if args.list_models:
-        models_table = get_model_table()
-        print(models_table)
-        return
-    
-    # Set model in config if provided as argument
     if args.model is not None:
         config.agent.code = config.agent.code.model_copy(update={"model": args.model})
 
+    user_request = resolve_user_request(args)
+    if user_request is None or user_request.strip() == "":
+        logger.error(
+            "No request provided. Please provide a prompt using --prompt or --prompt-file, or type it manually."
+        )
+        return
 
-    # Prepare to run AutoRecLab
+    log_user_request(out_dir, user_request, args.prompt_no_log)
+    await run_autoreclab(user_request, config, out_dir)
+
+
+def handle_management_command(args, out_dir) -> bool:
+    if args.init:
+        mkdir(out_dir / "workspace")
+        return True
+
+    if args.list_datasets:
+        datasets_table = get_datasets_table()
+        print(datasets_table)
+        return True
+
+    if args.list_models:
+        models_table = get_model_table()
+        print(models_table)
+        return True
+
+    return False
+
+
+def resolve_user_request(args) -> str | None:
+    if args.prompt is not None:
+        return args.prompt
+
+    if args.prompt_file is not None:
+        with open(args.prompt_file, "r", encoding="utf-8") as f:
+            return f.read().strip()
+
+    user_req_lines: list[str] = []
+    print('Enter you request, write "!start" to start:')
+    while True:
+        line = input("> ")
+        if line.lower().strip().startswith("!start"):
+            break
+        user_req_lines.append(line)
+
+    return "\n".join(user_req_lines)
+
+
+def log_user_request(out_dir, user_request: str, prompt_no_log: bool):
+    if prompt_no_log:
+        return
+
+    prompt_file = out_dir / "entered_prompt.txt"
+    with open(prompt_file, "w", encoding="utf-8") as f:
+        f.write(user_request)
+
+
+async def run_autoreclab(user_request: str, config, out_dir):
     attach_file_handler(out_dir)
     cost_tracker.set_out_dir(out_dir)
     statistics_tracker.set_out_dir(out_dir)
     require_executable("dot")
 
-
-    # Get user request
-    user_request = None
-
-    if args.prompt is not None:
-        user_request = args.prompt
-
-    elif args.prompt_file is not None:
-        with open(args.prompt_file, "r", encoding="utf-8") as f:
-            user_request = f.read().strip()
-
-    else:
-        user_req_lines: list[str] = []
-        print('Enter you request, write "!start" to start:')
-        while True:
-            line = input("> ")
-            if line.lower().strip().startswith("!start"):
-                break
-            user_req_lines.append(line)
-
-        user_request = "\n".join(user_req_lines)
-
-    if user_request is None or user_request.strip() == "":
-        logger.error("No request provided. Please provide a prompt using --prompt or --prompt-file, or type it manually.")
-        return
-    
-
-    # Log the user request
-    if not args.prompt_no_log:
-        prompt_file = out_dir / "entered_prompt.txt"
-        with open(prompt_file, "w", encoding="utf-8") as f:
-            f.write(user_request)
-
-
-    # Start AutoRecLab
     logger.info("Starting AutoRecLab...")
     logger.debug(f"User request:\n{user_request}")
     ts = TreeSearch(user_request, config=config)
     await ts._async_init()
     await ts.run()
 
-
-    # Summarize results
     cost_tracker.saveSummarized()
     statistics_tracker.summarize_statistics()
 


### PR DESCRIPTION
# Refactor CLI startup flow in `main.py`

## Problem
The current CLI entry point in [main.py](main.py) handles too many responsibilities in a single `main()` function. It mixes command handling, prompt acquisition, prompt logging, and the actual AutoRecLab execution path.

This makes the startup flow harder to read, harder to extend, and harder to test.

## Goal
Refactor the CLI startup logic into smaller, focused helpers while keeping the user-facing behavior unchanged.

## Proposed changes
- Extract handling for management commands:
  - `--init`
  - `--list-datasets`
  - `--list-models`
- Extract prompt resolution into a separate helper
- Extract prompt logging into a separate helper
- Extract the actual AutoRecLab execution into a dedicated function
- Keep the current CLI behavior and output unchanged

## Why this matters
- Improves readability of the entry point
- Makes future CLI changes safer
- Reduces branching inside `main()`
- Makes the startup path easier to test in isolation

## Acceptance criteria
- `main()` only coordinates the startup flow
- Command handling is separated from runtime execution
- Prompt resolution is isolated from the rest of the startup logic
- The application behavior remains unchanged for existing CLI options
- The refactor passes syntax and basic validation checks

## Validation
- `python -m py_compile main.py`
